### PR TITLE
Ported core functionality of E-Hub Configuration

### DIFF
--- a/results_UI.alp
+++ b/results_UI.alp
@@ -1015,6 +1015,141 @@ cm_consumptionColors.put(OL_EnergyCarriers.HYDROGEN, v_hydrogenDemandColor);
 						</InitialValue>
 					</Properties>
 				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391442</Id>
+					<Name><![CDATA[b_EHubConfiguration]]></Name>
+					<X>990</X><Y>710</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[boolean]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[false]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391446</Id>
+					<Name><![CDATA[v_groupATODeliveryCapacity_kW]]></Name>
+					<X>990</X><Y>730</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391449</Id>
+					<Name><![CDATA[v_groupATOFeedInCapacity_kW]]></Name>
+					<X>990</X><Y>750</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391451</Id>
+					<Name><![CDATA[v_dataEHubDeliveryCapacityLiveWeek_kW]]></Name>
+					<X>990</X><Y>770</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391454</Id>
+					<Name><![CDATA[v_dataEHubDeliveryCapacityYear_kW]]></Name>
+					<X>990</X><Y>790</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391457</Id>
+					<Name><![CDATA[v_dataEHubDeliveryCapacitySummerWeek_kW]]></Name>
+					<X>990</X><Y>810</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391459</Id>
+					<Name><![CDATA[v_dataEHubDeliveryCapacityWinterWeek_kW]]></Name>
+					<X>990</X><Y>830</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391462</Id>
+					<Name><![CDATA[v_dataEHubFeedInCapacityLiveWeek_kW]]></Name>
+					<X>990</X><Y>850</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391464</Id>
+					<Name><![CDATA[v_dataEHubFeedInCapacityYear_kW]]></Name>
+					<X>990</X><Y>870</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391467</Id>
+					<Name><![CDATA[v_dataEHubFeedInCapacitySummerWeek_kW]]></Name>
+					<X>990</X><Y>890</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736425391470</Id>
+					<Name><![CDATA[v_dataEHubFeedInCapacityWinterWeek_kW]]></Name>
+					<X>990</X><Y>910</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[DataSet]]></Type>        
+					</Properties>
+				</Variable>
 				<Variable Class="Parameter">
 					<Id>1715851154621</Id>
 					<Name><![CDATA[energyModel]]></Name>

--- a/results_UI.alp
+++ b/results_UI.alp
@@ -1150,6 +1150,36 @@ cm_consumptionColors.put(OL_EnergyCarriers.HYDROGEN, v_hydrogenDemandColor);
 						<Type><![CDATA[DataSet]]></Type>        
 					</Properties>
 				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736430624184</Id>
+					<Name><![CDATA[v_cumulativeGTVColor]]></Name>
+					<X>83</X><Y>2065</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[Color]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[burlyWood]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1736430624188</Id>
+					<Name><![CDATA[v_groupGTVColor]]></Name>
+					<X>83</X><Y>2085</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[Color]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[red]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
 				<Variable Class="Parameter">
 					<Id>1715851154621</Id>
 					<Name><![CDATA[energyModel]]></Name>
@@ -8383,9 +8413,9 @@ plot_trafo_week.setFixedVerticalScale(minValue + minValue * 0.15, maxValue + max
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1721117940765</Id>
+					<Id>1736430560710</Id>
 					<Name><![CDATA[f_addElectricityNetLoad_Live]]></Name>
-					<X>880</X><Y>750</Y>
+					<X>870</X><Y>750</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -8409,8 +8439,18 @@ if(dataObject.b_isRealFeedinCapacityAvailable){
 }
 
 group_netload_week.setVisible(true);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityLiveWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityLiveWeek_kW, feedinCapacityLabel, feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+
+if (uI_Results.b_EHubConfiguration && uI_Results.c_individualGridConnections.size() > 0) {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityLiveWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityLiveWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubDeliveryCapacityLiveWeek_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubFeedInCapacityLiveWeek_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+}
+else {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityLiveWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityLiveWeek_kW, feedinCapacityLabel, feedinCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+}
+
 plot_netload_week.addDataSet(dataObject.v_dataNetLoadLiveWeek_kW, "Netto vermogen", uI_Results.v_electricityDemandColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 4.0, Chart.PointStyle.POINT_NONE);
 
 for (AreaCollection AC : uI_Results.c_individualGridConnections) {
@@ -8425,10 +8465,10 @@ plot_netload_week.setFixedVerticalScale(minValue + minValue * 0.3, maxValue + ma
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1721121016887</Id>
+					<Id>1736430560714</Id>
 					<Name><![CDATA[f_addElectricityNetLoad_Year]]></Name>
 					<ExcludeFromBuild>true</ExcludeFromBuild>
-					<X>880</X><Y>800</Y>
+					<X>870</X><Y>800</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -8437,23 +8477,9 @@ plot_netload_week.setFixedVerticalScale(minValue + minValue * 0.3, maxValue + ma
 						<Name><![CDATA[dataObject]]></Name>
 						<Type><![CDATA[AreaCollection]]></Type>
 					</Parameter>
-					<Body><![CDATA[String deliveryCapacityLabel = "Geschatte piek leveringscapaciteit";
-String feedinCapacityLabel = "Geschatte piek terugleveringscapaciteit";
-Color  deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
-Color  feedinCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
-
-if(dataObject.b_isRealDeliveryCapacityAvailable){
-	deliveryCapacityLabel = "Piek leveringscapaciteit";
-	deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_known;
-}
-if(dataObject.b_isRealFeedinCapacityAvailable){
-	feedinCapacityLabel = "Piek terugleveringscapaciteit";
-	feedinCapacityColor		= uI_Results.v_electricityCapacityColor_known;
-}
-
-group_netload_year.setVisible(true);
-plot_netload_year.addDataSet(dataObject.v_dataElectricityDemandCapacityLiveWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
-plot_netload_year.addDataSet(dataObject.v_dataElectricitySupplyCapacityLiveWeek_kW, feedinCapacityLabel,  feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+					<Body><![CDATA[group_netload_year.setVisible(true);
+plot_netload_year.addDataSet(dataObject.v_dataElectricityDemandCapacityLiveWeek_kW, "Piek leveringscapaciteit", uI_Results.v_electricityCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+plot_netload_year.addDataSet(dataObject.v_dataElectricitySupplyCapacityLiveWeek_kW, "Piek terugleveringscapaciteit", uI_Results.v_electricityCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
 plot_netload_year.addDataSet(dataObject.v_dataNetLoadLiveWeek_kW, "Netto vermogen", uI_Results.v_electricityDemandColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1.5, Chart.PointStyle.POINT_NONE);
 
 int maxValue = roundToInt(max(dataObject.v_dataNetLoadLiveWeek_kW.getYMax(), dataObject.v_dataElectricityDemandCapacityLiveWeek_kW.getYMax()));
@@ -8464,9 +8490,9 @@ plot_netload_year.setFixedVerticalScale(minValue + minValue * 0.15, maxValue + m
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1721131765426</Id>
+					<Id>1736430560716</Id>
 					<Name><![CDATA[f_addElectricityNetLoad_SummerWeek]]></Name>
-					<X>880</X><Y>850</Y>
+					<X>870</X><Y>850</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -8490,8 +8516,18 @@ if(dataObject.b_isRealFeedinCapacityAvailable){
 }
 
 group_netload_week.setVisible(true);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacitySummerWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacitySummerWeek_kW, feedinCapacityLabel, feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+
+if (uI_Results.b_EHubConfiguration && uI_Results.c_individualGridConnections.size() > 0) {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacitySummerWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacitySummerWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubDeliveryCapacitySummerWeek_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubFeedInCapacitySummerWeek_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+}
+else {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacitySummerWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacitySummerWeek_kW, feedinCapacityLabel, feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+}
+
 plot_netload_week.addDataSet(dataObject.v_dataNetLoadSummerWeek_kW, "Netto vermogen", uI_Results.v_electricityDemandColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 4.0, Chart.PointStyle.POINT_NONE);
 
 for (AreaCollection AC : uI_Results.c_individualGridConnections) {
@@ -8506,9 +8542,9 @@ plot_netload_week.setFixedVerticalScale(minValue + minValue * 0.15, maxValue + m
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1721132333807</Id>
+					<Id>1736430560718</Id>
 					<Name><![CDATA[f_addElectricityNetLoad_WinterWeek]]></Name>
-					<X>880</X><Y>900</Y>
+					<X>870</X><Y>900</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -8532,8 +8568,19 @@ if(dataObject.b_isRealFeedinCapacityAvailable){
 }
 
 group_netload_week.setVisible(true);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityWinterWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
-plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityWinterWeek_kW, feedinCapacityLabel, feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+
+if (uI_Results.b_EHubConfiguration && uI_Results.c_individualGridConnections.size() > 0) {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityWinterWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityWinterWeek_kW, "Cumulatieve GTV afname van bedrijven", uI_Results.v_cumulativeGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubDeliveryCapacityWinterWeek_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(uI_Results.v_dataEHubFeedInCapacityWinterWeek_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+}
+else {
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityDeliveryCapacityWinterWeek_kW, deliveryCapacityLabel, deliveryCapacityColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_netload_week.addDataSet(dataObject.v_dataElectricityFeedInCapacityWinterWeek_kW, feedinCapacityLabel, feedinCapacityColor,true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+
+}
+
 plot_netload_week.addDataSet(dataObject.v_dataNetLoadWinterWeek_kW, "Netto vermogen", uI_Results.v_electricityDemandColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 4.0, Chart.PointStyle.POINT_NONE);
 
 for (AreaCollection AC : uI_Results.c_individualGridConnections) {
@@ -9748,55 +9795,6 @@ plot_seizoen.removeAll();]]></Body>
 				<Function AccessType="default" StaticFunction="false">
 					<ReturnModificator>VOID</ReturnModificator>
 					<ReturnType><![CDATA[double]]></ReturnType>
-					<Id>1714923068484</Id>
-					<Name><![CDATA[f_addTrafoLimits]]></Name>
-					<X>60</X><Y>830</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Parameter>
-						<Name><![CDATA[area]]></Name>
-						<Type><![CDATA[AreaCollection]]></Type>
-					</Parameter>
-					<Body><![CDATA[String deliveryCapacityLabel = "Geschatte capaciteit afname";
-String feedinCapacityLabel = "Geschatte capaciteit teruglevering";
-Color  deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
-Color  feedinCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
-
-if(area.b_isRealDeliveryCapacityAvailable){
-	deliveryCapacityLabel = "Capaciteit afname";
-	deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_known;
-}
-if(area.b_isRealFeedinCapacityAvailable){
-	feedinCapacityLabel = "Capaciteit teruglevering";
-	feedinCapacityColor		= uI_Results.v_electricityCapacityColor_known;
-}
-
-//Add and color grid capacities
-plot_jaar.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
-plot_jaar.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
-plot_jaar.setColor(1, deliveryCapacityColor);
-plot_jaar.setColor(2, feedinCapacityColor);
-
-plot_week.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
-plot_week.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
-plot_week.setColor(plot_week.getCount() - 2, deliveryCapacityColor);
-plot_week.setColor(plot_week.getCount() - 1, feedinCapacityColor);
-
-plot_dagnacht.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
-plot_dagnacht.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
-plot_dagnacht.setColor(plot_dagnacht.getCount() - 2, deliveryCapacityColor);
-plot_dagnacht.setColor(plot_dagnacht.getCount() - 1, feedinCapacityColor);
-
-plot_seizoen.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
-plot_seizoen.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
-plot_seizoen.setColor(plot_seizoen.getCount() - 2, deliveryCapacityColor);
-plot_seizoen.setColor(plot_seizoen.getCount() - 1, feedinCapacityColor);]]></Body>
-				</Function>
-				<Function AccessType="default" StaticFunction="false">
-					<ReturnModificator>VOID</ReturnModificator>
-					<ReturnType><![CDATA[double]]></ReturnType>
 					<Id>1714923776978</Id>
 					<Name><![CDATA[f_addDataToPlots]]></Name>
 					<X>60</X><Y>810</Y>
@@ -9854,6 +9852,87 @@ if( area.v_dataNetbelastingDuurkrommeWeekday_kW != null){
 	plot_week.setFixedVerticalScale(scaleMin_kW, scaleMax_kW);
 }
 ]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1736430711431</Id>
+					<Name><![CDATA[f_addTrafoLimits]]></Name>
+					<X>60</X><Y>830</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[area]]></Name>
+						<Type><![CDATA[AreaCollection]]></Type>
+					</Parameter>
+					<Body><![CDATA[//Add and color grid capacities
+if (uI_Results.b_EHubConfiguration && uI_Results.c_individualGridConnections.size() > 0) {
+	plot_jaar.addDataSet(area.data_gridCapacityDeliveryYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_jaar.addDataSet(area.data_gridCapacityFeedInYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_jaar.setColor(1, uI_Results.v_cumulativeGTVColor);
+	plot_jaar.setColor(2, uI_Results.v_cumulativeGTVColor);
+	
+	plot_week.addDataSet(area.data_gridCapacityDeliveryYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_week.addDataSet(area.data_gridCapacityFeedInYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_week.setColor(plot_week.getCount() - 2, uI_Results.v_cumulativeGTVColor);
+	plot_week.setColor(plot_week.getCount() - 1, uI_Results.v_cumulativeGTVColor);
+	
+	plot_dagnacht.addDataSet(area.data_gridCapacityDeliveryYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_dagnacht.addDataSet(area.data_gridCapacityFeedInYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_dagnacht.setColor(plot_dagnacht.getCount() - 2, uI_Results.v_cumulativeGTVColor);
+	plot_dagnacht.setColor(plot_dagnacht.getCount() - 1, uI_Results.v_cumulativeGTVColor);
+	
+	plot_seizoen.addDataSet(area.data_gridCapacityDeliveryYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_seizoen.addDataSet(area.data_gridCapacityFeedInYear_kW,"Cumulatieve GTV afname van bedrijven");
+	plot_seizoen.setColor(plot_seizoen.getCount() - 2, uI_Results.v_cumulativeGTVColor);
+	plot_seizoen.setColor(plot_seizoen.getCount() - 1, uI_Results.v_cumulativeGTVColor);
+	
+	plot_jaar.addDataSet(uI_Results.v_dataEHubDeliveryCapacityYear_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_jaar.addDataSet(uI_Results.v_dataEHubFeedInCapacityYear_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+	plot_week.addDataSet(uI_Results.v_dataEHubDeliveryCapacityYear_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_week.addDataSet(uI_Results.v_dataEHubFeedInCapacityYear_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+	plot_dagnacht.addDataSet(uI_Results.v_dataEHubDeliveryCapacityYear_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_dagnacht.addDataSet(uI_Results.v_dataEHubFeedInCapacityYear_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+	plot_seizoen.addDataSet(uI_Results.v_dataEHubDeliveryCapacityYear_kW, "Groeps GTV afname (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);
+	plot_seizoen.addDataSet(uI_Results.v_dataEHubFeedInCapacityYear_kW, "Groeps GTV teruglevering (Rekenmethode Stedin)", uI_Results.v_groupGTVColor, true, false, Chart.InterpolationType.INTERPOLATION_LINEAR, 1, Chart.PointStyle.POINT_NONE);	
+}
+else {
+	String deliveryCapacityLabel = "Geschatte capaciteit afname";
+	String feedinCapacityLabel = "Geschatte capaciteit teruglevering";
+	Color  deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
+	Color  feedinCapacityColor		= uI_Results.v_electricityCapacityColor_estimated;
+	
+	if(area.b_isRealDeliveryCapacityAvailable){
+		deliveryCapacityLabel = "Capaciteit afname";
+		deliveryCapacityColor		= uI_Results.v_electricityCapacityColor_known;
+	}
+	if(area.b_isRealFeedinCapacityAvailable){
+		feedinCapacityLabel = "Capaciteit teruglevering";
+		feedinCapacityColor		= uI_Results.v_electricityCapacityColor_known;
+	}
+
+	plot_jaar.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
+	plot_jaar.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
+	plot_jaar.setColor(1, deliveryCapacityColor);
+	plot_jaar.setColor(2, feedinCapacityColor);
+	
+	plot_week.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
+	plot_week.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
+	plot_week.setColor(plot_week.getCount() - 2, deliveryCapacityColor);
+	plot_week.setColor(plot_week.getCount() - 1, feedinCapacityColor);
+	
+	plot_dagnacht.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
+	plot_dagnacht.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
+	plot_dagnacht.setColor(plot_dagnacht.getCount() - 2, deliveryCapacityColor);
+	plot_dagnacht.setColor(plot_dagnacht.getCount() - 1, feedinCapacityColor);
+	
+	plot_seizoen.addDataSet(area.data_gridCapacityDeliveryYear_kW, deliveryCapacityLabel);
+	plot_seizoen.addDataSet(area.data_gridCapacityFeedInYear_kW, feedinCapacityLabel);
+	plot_seizoen.setColor(plot_seizoen.getCount() - 2, deliveryCapacityColor);
+	plot_seizoen.setColor(plot_seizoen.getCount() - 1, feedinCapacityColor);
+}]]></Body>
 				</Function>
 			</Functions>
 			<AgentLinks>


### PR DESCRIPTION
In the line plots of net load and the netloaddurationcurve if there is an E-Hub selected it replaces the (estimated) connection capacity with 2 lines: 
The sum of the original connection capacities and the group connection capacity (as would be calculated by Stedin)