### PR TITLE
Netbelastingduurkromme rework

### DIFF
--- a/_alp/Agents/ChartGespreksleidraadBedrijven/Code/Functions.java
+++ b/_alp/Agents/ChartGespreksleidraadBedrijven/Code/Functions.java
@@ -193,7 +193,6 @@ energySupplyChartYearGespreksleidraad1.addDataSet(data.getRapidRunData().acc_dai
 
 double maxScale = max(data.getRapidRunData().am_dailyAverageConsumptionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getMaxPower_kW(),data.getRapidRunData().am_dailyAverageProductionAccumulators_kW.get(OL_EnergyCarriers.ELECTRICITY).getMaxPower_kW());
 //double maxScale = max(energySupplyChartYearGespreksleidraad1.getScaleY(), energyDemandChartYearGespreksleidraad1.getScaleY());
-traceln("maxScale: %s", maxScale);
 energyDemandChartYearGespreksleidraad1.setFixedVerticalScale(0, maxScale);
 energySupplyChartYearGespreksleidraad1.setFixedVerticalScale(maxScale);
 

--- a/_alp/Agents/ChartNetbelasting/AOC.ChartNetbelasting.xml
+++ b/_alp/Agents/ChartNetbelasting/AOC.ChartNetbelasting.xml
@@ -2,6 +2,7 @@
 <ActiveObjectClass>
 	<Id>1714746096727</Id>
 	<Name><![CDATA[ChartNetbelasting]]></Name>
+	<Import><![CDATA[import java.text.DecimalFormat;]]></Import>
 	<ExtendsReference>
 		<PackageName>digital_twin_results</PackageName>
 		<ClassName>ChartArea</ClassName>

--- a/_alp/Agents/ChartNetbelasting/Code/Functions.xml
+++ b/_alp/Agents/ChartNetbelasting/Code/Functions.xml
@@ -22,7 +22,7 @@
 		<Id>1714746143911</Id>
 		<Name><![CDATA[f_setNetAverageLoad]]></Name>
 		<X>60</X>
-		<Y>870</Y>
+		<Y>890</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -84,7 +84,7 @@
 		<ReturnModificator>VOID</ReturnModificator>
 		<ReturnType>double</ReturnType>
 		<Id>1740584474407</Id>
-		<Name><![CDATA[f_addTrafoLimits]]></Name>
+		<Name><![CDATA[f_addConnectionLimits]]></Name>
 		<X>60</X>
 		<Y>830</Y>
 		<Label>
@@ -122,7 +122,7 @@
 		<Id>1741699130821</Id>
 		<Name><![CDATA[f_setNetAverageLoadGN]]></Name>
 		<X>370</X>
-		<Y>850</Y>
+		<Y>890</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -163,6 +163,50 @@
 		<Name><![CDATA[f_addTrafoLimitsGN]]></Name>
 		<X>370</X>
 		<Y>830</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[GN]]></Name>
+			<Type><![CDATA[GridNode]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1743519606875</Id>
+		<Name><![CDATA[f_setMaxPeakValues]]></Name>
+		<X>60</X>
+		<Y>870</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[dataObject]]></Name>
+			<Type><![CDATA[I_EnergyData]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[loadDurationCurves]]></Name>
+			<Type><![CDATA[J_LoadDurationCurves]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1743519634438</Id>
+		<Name><![CDATA[f_setMaxPeakValuesGN]]></Name>
+		<X>370</X>
+		<Y>870</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>

--- a/_alp/Agents/ChartNetbelasting/Code/Functions.xml
+++ b/_alp/Agents/ChartNetbelasting/Code/Functions.xml
@@ -85,7 +85,7 @@
 		<ReturnType>double</ReturnType>
 		<Id>1740584474407</Id>
 		<Name><![CDATA[f_addConnectionLimits]]></Name>
-		<X>60</X>
+		<X>80</X>
 		<Y>830</Y>
 		<Label>
 			<X>10</X>
@@ -97,6 +97,10 @@
 		<Parameter>
 			<Name><![CDATA[dataObject]]></Name>
 			<Type><![CDATA[I_EnergyData]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[divisionAmountForCorrectUnit]]></Name>
+			<Type><![CDATA[double]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
@@ -161,7 +165,7 @@
 		<ReturnType>double</ReturnType>
 		<Id>1741699130827</Id>
 		<Name><![CDATA[f_addTrafoLimitsGN]]></Name>
-		<X>370</X>
+		<X>390</X>
 		<Y>830</Y>
 		<Label>
 			<X>10</X>
@@ -174,11 +178,15 @@
 			<Name><![CDATA[GN]]></Name>
 			<Type><![CDATA[GridNode]]></Type>
 		</Parameter>
+		<Parameter>
+			<Name><![CDATA[divisionAmountForCorrectUnit]]></Name>
+			<Type><![CDATA[double]]></Type>
+		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>
 	<Function AccessType="default" StaticFunction="false">
 		<ReturnModificator>VOID</ReturnModificator>
-		<ReturnType>double</ReturnType>
+		<ReturnType>String</ReturnType>
 		<Id>1743519606875</Id>
 		<Name><![CDATA[f_setMaxPeakValues]]></Name>
 		<X>60</X>
@@ -217,6 +225,26 @@
 		<Parameter>
 			<Name><![CDATA[GN]]></Name>
 			<Type><![CDATA[GridNode]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>VOID</ReturnModificator>
+		<ReturnType>double</ReturnType>
+		<Id>1743761224093</Id>
+		<Name><![CDATA[f_setYlabels_loadDurationCurve]]></Name>
+		<X>50</X>
+		<Y>1000</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[power_unit]]></Name>
+			<Type><![CDATA[String]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/ChartNetbelasting/Levels/Level.level.xml
+++ b/_alp/Agents/ChartNetbelasting/Levels/Level.level.xml
@@ -30,7 +30,7 @@
 	</Rectangle>
 	<Group>
 		<Id>1714923210771</Id>
-		<Name><![CDATA[group_details]]></Name>
+		<Name><![CDATA[gr_details]]></Name>
 		<X>680</X>
 		<Y>380</Y>
 		<Label>
@@ -453,7 +453,7 @@
 	</Group>
 	<Group>
 		<Id>1714923230147</Id>
-		<Name><![CDATA[group_jaar]]></Name>
+		<Name><![CDATA[gr_year]]></Name>
 		<X>230</X>
 		<Y>330</Y>
 		<Label>
@@ -471,8 +471,8 @@
 			<Oval>
 				<Id>1714926452654</Id>
 				<Name><![CDATA[ovalNetbelasting2]]></Name>
-				<X>28</X>
-				<Y>230</Y>
+				<X>15</X>
+				<Y>200</Y>
 				<Label>
 					<X>0</X>
 					<Y>0</Y>
@@ -497,8 +497,8 @@
 			<Oval>
 				<Id>1714926519243</Id>
 				<Name><![CDATA[ovalNetbelasting3]]></Name>
-				<X>150</X>
-				<Y>230</Y>
+				<X>155</X>
+				<Y>200</Y>
 				<Label>
 					<X>0</X>
 					<Y>0</Y>
@@ -656,9 +656,9 @@
 			</Text>
 			<Text>
 				<Id>1714746143901</Id>
-				<Name><![CDATA[tx_topBarplotText52]]></Name>
-				<X>40</X>
-				<Y>170</Y>
+				<Name><![CDATA[txt_maxDelivery_MW]]></Name>
+				<X>15</X>
+				<Y>130</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -675,15 +675,15 @@
 				<Font>
 					<Name><![CDATA[Arial]]></Name>
 					<Size>14</Size>
-					<Style>0</Style>
+					<Style>1</Style>
 				</Font>
 				<Alignment>CENTER</Alignment>
 			</Text>
 			<Text>
 				<Id>1714746143903</Id>
-				<Name><![CDATA[tx_maxDemand]]></Name>
-				<X>28</X>
-				<Y>220</Y>
+				<Name><![CDATA[t_maxDelivery_MW]]></Name>
+				<X>15</X>
+				<Y>190</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -699,16 +699,16 @@
 				<Text><![CDATA[xx MW]]></Text>
 				<Font>
 					<Name><![CDATA[Arial]]></Name>
-					<Size>14</Size>
+					<Size>16</Size>
 					<Style>1</Style>
 				</Font>
 				<Alignment>CENTER</Alignment>
 			</Text>
 			<Text>
 				<Id>1714746143905</Id>
-				<Name><![CDATA[tx_maxSupply]]></Name>
-				<X>149</X>
-				<Y>220</Y>
+				<Name><![CDATA[t_maxFeedin_MW]]></Name>
+				<X>155</X>
+				<Y>190</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -724,16 +724,16 @@
 				<Text><![CDATA[xx MW]]></Text>
 				<Font>
 					<Name><![CDATA[Arial]]></Name>
-					<Size>14</Size>
+					<Size>16</Size>
 					<Style>1</Style>
 				</Font>
 				<Alignment>CENTER</Alignment>
 			</Text>
 			<Text>
 				<Id>1714746143907</Id>
-				<Name><![CDATA[tx_topBarplotText55]]></Name>
+				<Name><![CDATA[txt_maxFeedin_MW]]></Name>
 				<X>155</X>
-				<Y>170</Y>
+				<Y>130</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -750,15 +750,15 @@
 				<Font>
 					<Name><![CDATA[Arial]]></Name>
 					<Size>14</Size>
-					<Style>0</Style>
+					<Style>1</Style>
 				</Font>
 				<Alignment>CENTER</Alignment>
 			</Text>
 			<Oval>
 				<Id>1714746143895</Id>
 				<Name><![CDATA[ovalNetbelasting1]]></Name>
-				<X>-125</X>
-				<Y>232</Y>
+				<X>-145</X>
+				<Y>200</Y>
 				<Label>
 					<X>0</X>
 					<Y>0</Y>
@@ -783,8 +783,8 @@
 			<Text>
 				<Id>1714746143899</Id>
 				<Name><![CDATA[t_KPIBenuttingsgraad]]></Name>
-				<X>-125</X>
-				<Y>215</Y>
+				<X>-145</X>
+				<Y>186</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -800,7 +800,7 @@
 				<Text><![CDATA[20%]]></Text>
 				<TextCode>//roundToInt(energyModel.v_avgNetLoad_fr*100) + "%"</TextCode>
 				<Font>
-					<Name><![CDATA[SansSerif]]></Name>
+					<Name><![CDATA[Arial]]></Name>
 					<Size>22</Size>
 					<Style>1</Style>
 				</Font>
@@ -809,8 +809,8 @@
 			<Text>
 				<Id>1714746143897</Id>
 				<Name><![CDATA[text1123]]></Name>
-				<X>-120</X>
-				<Y>287</Y>
+				<X>-145</X>
+				<Y>255</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -825,7 +825,7 @@
 				<Color>-16777216</Color>
 				<Text><![CDATA[Gemiddelde benutting]]></Text>
 				<Font>
-					<Name><![CDATA[SansSerif]]></Name>
+					<Name><![CDATA[Arial]]></Name>
 					<Size>14</Size>
 					<Style>0</Style>
 				</Font>
@@ -833,9 +833,9 @@
 			</Text>
 			<Text>
 				<Id>1714746143893</Id>
-				<Name><![CDATA[text593]]></Name>
-				<X>-120</X>
-				<Y>150</Y>
+				<Name><![CDATA[txt_benuttingsGraad]]></Name>
+				<X>-145</X>
+				<Y>130</Y>
 				<Label>
 					<X>0</X>
 					<Y>-10</Y>
@@ -850,8 +850,162 @@
 				<Color>-16777216</Color>
 				<Text><![CDATA[Benuttingsgraad]]></Text>
 				<Font>
-					<Name><![CDATA[Calibri]]></Name>
-					<Size>20</Size>
+					<Name><![CDATA[Arial]]></Name>
+					<Size>14</Size>
+					<Style>1</Style>
+				</Font>
+				<Alignment>CENTER</Alignment>
+			</Text>
+			<Oval>
+				<Id>1743519403232</Id>
+				<Name><![CDATA[ovalNetbelasting4]]></Name>
+				<X>15</X>
+				<Y>330</Y>
+				<Label>
+					<X>0</X>
+					<Y>0</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<ZHeight>10</ZHeight>
+				<LineWidth>1</LineWidth>
+				<LineColor/>
+				<LineMaterial>null</LineMaterial>
+				<LineStyle>SOLID</LineStyle>
+				<RadiusX>40</RadiusX>
+				<RadiusY>40</RadiusY>
+				<Rotation>0.0</Rotation>
+				<FillColor>-2180985</FillColor>
+				<FillMaterial>null</FillMaterial>
+			</Oval>
+			<Oval>
+				<Id>1743519403240</Id>
+				<Name><![CDATA[ovalNetbelasting5]]></Name>
+				<X>155</X>
+				<Y>330</Y>
+				<Label>
+					<X>0</X>
+					<Y>0</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<ZHeight>10</ZHeight>
+				<LineWidth>1</LineWidth>
+				<LineColor/>
+				<LineMaterial>null</LineMaterial>
+				<LineStyle>SOLID</LineStyle>
+				<RadiusX>40</RadiusX>
+				<RadiusY>40</RadiusY>
+				<Rotation>0.0</Rotation>
+				<FillColor>-12799119</FillColor>
+				<FillMaterial>null</FillMaterial>
+			</Oval>
+			<Text>
+				<Id>1743519403246</Id>
+				<Name><![CDATA[t_maxDelivery_pct]]></Name>
+				<X>15</X>
+				<Y>320</Y>
+				<Label>
+					<X>0</X>
+					<Y>-10</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<Rotation>0.0</Rotation>
+				<Color>-1</Color>
+				<Text><![CDATA[xx %]]></Text>
+				<Font>
+					<Name><![CDATA[Arial]]></Name>
+					<Size>18</Size>
+					<Style>1</Style>
+				</Font>
+				<Alignment>CENTER</Alignment>
+			</Text>
+			<Text>
+				<Id>1743519403248</Id>
+				<Name><![CDATA[t_maxFeedin_pct]]></Name>
+				<X>155</X>
+				<Y>320</Y>
+				<Label>
+					<X>0</X>
+					<Y>-10</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<Rotation>0.0</Rotation>
+				<Color>-1</Color>
+				<Text><![CDATA[xx %]]></Text>
+				<Font>
+					<Name><![CDATA[Arial]]></Name>
+					<Size>18</Size>
+					<Style>1</Style>
+				</Font>
+				<Alignment>CENTER</Alignment>
+			</Text>
+			<Text>
+				<Id>1743520021109</Id>
+				<Name><![CDATA[txt_maxFeedin_MW1]]></Name>
+				<X>155</X>
+				<Y>250</Y>
+				<Label>
+					<X>0</X>
+					<Y>-10</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<Rotation>0.0</Rotation>
+				<Color>-16777216</Color>
+				<Text><![CDATA[als percentage van 
+teruglever capaciteit]]></Text>
+				<Font>
+					<Name><![CDATA[Arial]]></Name>
+					<Size>14</Size>
+					<Style>0</Style>
+				</Font>
+				<Alignment>CENTER</Alignment>
+			</Text>
+			<Text>
+				<Id>1743520079522</Id>
+				<Name><![CDATA[txt_maxFeedin_MW2]]></Name>
+				<X>15</X>
+				<Y>250</Y>
+				<Label>
+					<X>0</X>
+					<Y>-10</Y>
+				</Label>
+				<PublicFlag>true</PublicFlag>
+				<PresentationFlag>true</PresentationFlag>
+				<ShowLabel>false</ShowLabel>
+				<DrawMode>SHAPE_DRAW_2D</DrawMode>
+				<EmbeddedIcon>false</EmbeddedIcon>
+				<Z>0</Z>
+				<Rotation>0.0</Rotation>
+				<Color>-16777216</Color>
+				<Text><![CDATA[als percentage van 
+afname capaciteit]]></Text>
+				<Font>
+					<Name><![CDATA[Arial]]></Name>
+					<Size>14</Size>
 					<Style>0</Style>
 				</Font>
 				<Alignment>CENTER</Alignment>
@@ -877,12 +1031,12 @@
 			<TextColor/>
 			<Enabled>true</Enabled>
 			<ActionCode>if (radio.getValue() == 0){
-	group_jaar.setVisible(true);
-	group_details.setVisible(false);
+	gr_year.setVisible(true);
+	gr_details.setVisible(false);
 }
 else {
-	group_jaar.setVisible(false);
-	group_details.setVisible(true);
+	gr_year.setVisible(false);
+	gr_details.setVisible(true);
 }</ActionCode>
 		</BasicProperties>
 		<ExtendedProperties>

--- a/_alp/Agents/UI_Results/Code/Functions.java
+++ b/_alp/Agents/UI_Results/Code/Functions.java
@@ -596,3 +596,21 @@ else{
 
 /*ALCODEEND*/}
 
+DataSet f_createNewDataSetDividedByValue(DataSet inputDataSet,double dividedByValue)
+{/*ALCODESTART::1743689452038*/
+if(dividedByValue == 0){
+	new RuntimeException("Can't divide a dataset by zero!");
+}
+
+if(dividedByValue == 1){
+	return inputDataSet;
+}
+
+DataSet newDataset = new DataSet(inputDataSet.size());
+for (int i = 0; i < inputDataSet.size(); i++) {
+    double newValue = inputDataSet.getY(i) / dividedByValue;
+    newDataset.add(inputDataSet.getX(i), newValue);
+}
+return newDataset;
+/*ALCODEEND*/}
+

--- a/_alp/Agents/UI_Results/Code/Functions.xml
+++ b/_alp/Agents/UI_Results/Code/Functions.xml
@@ -533,8 +533,8 @@
 		<ReturnType>DataSet</ReturnType>
 		<Id>1740750008518</Id>
 		<Name><![CDATA[f_createFlatDataset]]></Name>
-		<X>540</X>
-		<Y>950</Y>
+		<X>530</X>
+		<Y>930</Y>
 		<Label>
 			<X>10</X>
 			<Y>0</Y>
@@ -649,6 +649,30 @@
 		<Parameter>
 			<Name><![CDATA[setVisible]]></Name>
 			<Type><![CDATA[boolean]]></Type>
+		</Parameter>
+		<Body xmlns:al="http://anylogic.com"/>
+	</Function>
+	<Function AccessType="default" StaticFunction="false">
+		<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+		<ReturnType>DataSet</ReturnType>
+		<Id>1743689452038</Id>
+		<Name><![CDATA[f_createNewDataSetDividedByValue]]></Name>
+		<X>530</X>
+		<Y>960</Y>
+		<Label>
+			<X>10</X>
+			<Y>0</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>true</ShowLabel>
+		<Parameter>
+			<Name><![CDATA[inputDataSet]]></Name>
+			<Type><![CDATA[DataSet]]></Type>
+		</Parameter>
+		<Parameter>
+			<Name><![CDATA[dividedByValue]]></Name>
+			<Type><![CDATA[double]]></Type>
 		</Parameter>
 		<Body xmlns:al="http://anylogic.com"/>
 	</Function>

--- a/_alp/Agents/UI_Results/Levels/Level.level.xml
+++ b/_alp/Agents/UI_Results/Levels/Level.level.xml
@@ -1358,7 +1358,7 @@ else{
 		<Id>1743501981947</Id>
 		<Name><![CDATA[cb_EhubConfig]]></Name>
 		<X>520</X>
-		<Y>900</Y>
+		<Y>880</Y>
 		<Label>
 			<X>0</X>
 			<Y>-10</Y>

--- a/_alp/Agents/UI_Results/Levels/Level.level.xml
+++ b/_alp/Agents/UI_Results/Levels/Level.level.xml
@@ -1125,7 +1125,7 @@ else{
 		<LineMaterial>null</LineMaterial>
 		<LineStyle>SOLID</LineStyle>
 		<Width>380</Width>
-		<Height>450</Height>
+		<Height>540</Height>
 		<Rotation>0.0</Rotation>
 		<FillColor>-1</FillColor>
 		<FillMaterial>null</FillMaterial>
@@ -1353,4 +1353,44 @@ else{
 			</Text>
 		</Presentation>
 	</Group>
+	<Control Type="CheckBox">
+		<EmbeddedIcon>false</EmbeddedIcon>
+		<Id>1743501981947</Id>
+		<Name><![CDATA[cb_EhubConfig]]></Name>
+		<X>520</X>
+		<Y>900</Y>
+		<Label>
+			<X>0</X>
+			<Y>-10</Y>
+		</Label>
+		<PublicFlag>false</PublicFlag>
+		<PresentationFlag>true</PresentationFlag>
+		<ShowLabel>false</ShowLabel>
+		<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+		<BasicProperties Width="210" Height="30">
+			<EmbeddedIcon>false</EmbeddedIcon>
+			<TextColor/>
+			<VisibleCode>v_selectedObjectScope == OL_ResultScope.ENERGYCOOP</VisibleCode>
+			<Enabled>true</Enabled>
+			<EnableExpression>v_selectedObjectScope == OL_ResultScope.ENERGYCOOP</EnableExpression>
+			<ActionCode>if(cb_EhubConfig.isSelected()){
+	v_selectedChartType = OL_ChartTypes.GESPREKSLEIDRAAD_BEDRIJVEN;
+	f_showCorrectChart();
+	getRadioButtons().setValue(100, false);
+	chartGespreksleidraadBedrijven.getRb_gespreksleidraadBedrijvenChartType().setValue(2, true);
+}
+else{
+	if(getRadioButtons().getValue() == 100){
+		getRadioButtons().setValue(0, true);
+	}
+	f_showCorrectChart();
+}</ActionCode>
+		</BasicProperties>
+		<ExtendedProperties>
+			<Font Name="Dialog" Size="11" Style="0"/>
+			<LabelText>Toon groepscontract waarde</LabelText>
+			<LinkTo>true</LinkTo>
+			<Link>b_showGroupContractValues</Link>
+		</ExtendedProperties>
+	</Control>
 </Presentation>


### PR DESCRIPTION
- Piek/totale capaciteit percentages nu weergegeven voor levering en teruglevering.
- Herschrijven van KPI functies voor de netbelasting duurkromme (Benuttingsgraad en pieken).
- Correcte decimalen + eenheid format geimplementeerd voor de KPIs.